### PR TITLE
fix zabbix_sender failed when send complex keys without quotas

### DIFF
--- a/zabbix-redis.py
+++ b/zabbix-redis.py
@@ -100,7 +100,7 @@ def send(options):
         if instance:
             items = stats(instance, options.redis_type, options.redis_password)
             for name, value in items.items():
-                row = '- redis_%(type)s.info["%(instance)s","%(key)s"] %(tst)d %(value)s\n' % {
+                 row = '- \'redis_%(type)s.info["%(instance)s","%(key)s"]\' %(tst)d %(value)s\n' % {
                     'type': options.redis_type,
                     'instance': str2key(instance),
                     'key': str2key(name),

--- a/zabbix-redis.py
+++ b/zabbix-redis.py
@@ -100,7 +100,7 @@ def send(options):
         if instance:
             items = stats(instance, options.redis_type, options.redis_password)
             for name, value in items.items():
-                 row = '- \'redis_%(type)s.info["%(instance)s","%(key)s"]\' %(tst)d %(value)s\n' % {
+                row = '- \'redis_%(type)s.info["%(instance)s","%(key)s"]\' %(tst)d %(value)s\n' % {
                     'type': options.redis_type,
                     'instance': str2key(instance),
                     'key': str2key(name),

--- a/zabbix-redis.py
+++ b/zabbix-redis.py
@@ -111,7 +111,7 @@ def send(options):
                 rows += row
 
     # Submit metrics.
-    rc, output = execute('zabbix_sender -T -r -i - %(config)s %(server)s %(port)s %(host)s' % {
+    cmd = 'zabbix_sender -vv -T -r -i - %(config)s %(server)s %(port)s %(host)s' % {
         'config':
             '-c "%s"' % options.zabbix_config
             if options.zabbix_config is not None else '',
@@ -124,13 +124,13 @@ def send(options):
         'host':
             '-s "%s"' % options.zabbix_host
             if options.zabbix_host is not None else '',
-    }, stdin=rows)
+    }
+    sys.stdout.write(cmd)
+    rc, output = execute(cmd, stdin=rows)
 
+    sys.stdout.write(output)
     # Check return code.
-    if rc == 0:
-        sys.stdout.write(output)
-    else:
-        sys.stderr.write(output)
+    if rc != 0:
         sys.exit(1)
 
 


### PR DESCRIPTION
when i'm testing zabbix-redis.py with zabbix-agent 2.4.x and zabbix-server 3.2.x and add quotas to key name it works fine
```bash
echo - 'redis_server.info["10.0.3.20:6379","keyspace:db0:expires"]' 1505816872 1 | zabbix_sender -vv -T -r -i - -c /etc/zabbix/zabbix_agentd.conf
zabbix_sender [9928]: DEBUG: answer [{"response":"success","info":"processed: 1; failed: 0; total: 1; seconds spent: 0.000030"}]
info from server: "processed: 1; failed: 0; total: 1; seconds spent: 0.000030"
sent: 1; skipped: 0; total: 1
```
and failed when i not use quotas
```bash
echo - redis_server.info["10.0.3.20:6379","keyspace:db0:expires"] 1505816872 1 | zabbix_sender -vv -T -r -i - -c /etc/zabbix/zabbix_a
gentd.conf
zabbix_sender [10567]: DEBUG: answer [{"response":"success","info":"processed: 0; failed: 1; total: 1; seconds spent: 0.000021"}]
info from server: "processed: 0; failed: 1; total: 1; seconds spent: 0.000021"
``